### PR TITLE
fix: remove unnecessary import that breaks build

### DIFF
--- a/src/metricCollector.ts
+++ b/src/metricCollector.ts
@@ -1,6 +1,5 @@
 import { Queue, QueueEvents, QueueOptions } from 'bullmq';
 import * as Logger from 'bunyan';
-import { EventEmitter } from 'events';
 import IoRedis, { Redis } from 'ioredis';
 import { register as globalRegister, Registry } from 'prom-client';
 


### PR DESCRIPTION
fix: remove unnecessary import that breaks build and creation of Docker image, see https://github.com/marius-juro/bullmq_exporter/actions/runs/4144214180/jobs/7166992610