### PR TITLE
fix: add connection param when instantiating QueueEvents.

### DIFF
--- a/src/metricCollector.ts
+++ b/src/metricCollector.ts
@@ -66,7 +66,8 @@ export class MetricCollector {
 				}),
 				prefix: this.bullOpts.prefix || 'bull',
 				queueEvents: new QueueEvents(name, {
-					connection: this.defaultRedisClient,
+					...this.bullOpts,
+					connection: new IoRedis(this.redisUri), // QueueEvents instances must not reuse Redis connections, see https://docs.bullmq.io/guide/connections
 				}),
 			});
     }

--- a/src/metricCollector.ts
+++ b/src/metricCollector.ts
@@ -59,14 +59,16 @@ export class MetricCollector {
       }
       this.logger.info('added queue', name);
       this.queuesByName.set(name, {
-        name,
-        queue: new Queue(name, {
-          ...this.bullOpts,
-          connection: this.defaultRedisClient,
-        }),
-        prefix: this.bullOpts.prefix || 'bull',
-        queueEvents: new QueueEvents(name)
-      });
+				name,
+				queue: new Queue(name, {
+					...this.bullOpts,
+					connection: this.defaultRedisClient,
+				}),
+				prefix: this.bullOpts.prefix || 'bull',
+				queueEvents: new QueueEvents(name, {
+					connection: this.defaultRedisClient,
+				}),
+			});
     }
   }
 


### PR DESCRIPTION
In bullmq_exporter, when instantiating the QueueEvents connection is not explicitly passed.

Pass the connection when instantiating `QueueEvents` just like for `Queue`.