### PR TITLE
feat: add prioritized messages metric collection, upgrade bullmq

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,14 +39,15 @@ this can also be triggered manually from the `/discover_queues` endpoint
 
 ## Metrics
 
-| Metric                       | type    | description |
-|------------------------------|---------|-------------|
+| Metric                       | type    | description                                             |
+|------------------------------|---------|---------------------------------------------------------|
 | bull_queue_completed         | counter | Total number of completed jobs                          |
 | bull_queue_complete_duration | summary | Processing time for completed jobs                      |
 | bull_queue_active            | counter | Total number of active jobs (currently being processed) |
 | bull_queue_delayed           | counter | Total number of jobs that will run in the future        |
 | bull_queue_failed            | counter | Total number of failed jobs                             |
 | bull_queue_waiting           | counter | Total number of jobs waiting to be processed            |
+| bull_queue_prioritized       | counter | Total number of prioritized jobs                        |
 
 ## Kubernetes Usage
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@types/bunyan": "^1.8.5",
     "@types/uuid": "^8.0.0",
     "@types/yargs": "^15.0.0",
-    "bullmq": "^3.6.1",
+    "bullmq": "^5.7.1",
     "bunyan": "^1.8.12",
     "express": "^4.17.1",
     "prom-client": "^12.0.0",

--- a/src/queueGauges.ts
+++ b/src/queueGauges.ts
@@ -9,6 +9,7 @@ export interface QueueGauges {
 	failed: Gauge<LabelsT>;
 	waiting: Gauge<LabelsT>;
 	completeSummary: Summary<LabelsT>;
+	prioritized: Gauge<LabelsT>;
 }
 
 export function makeGuages(statPrefix: string, registers: Registry[]): QueueGauges {
@@ -51,6 +52,12 @@ export function makeGuages(statPrefix: string, registers: Registry[]): QueueGaug
 			help: 'Number of waiting messages',
 			labelNames: ['queue', 'prefix'],
 		}),
+		prioritized: new Gauge({
+			registers,
+			name: `${statPrefix}prioritized`,
+			help: 'Number of prioritized messages',
+			labelNames: ['queue', 'prefix'],
+		}),
 	};
 }
 
@@ -63,11 +70,12 @@ export async function getJobCompleteStats(prefix: string, name: string, job: Job
 }
 
 export async function getStats(prefix: string, name: string, queue: Queue, gauges: QueueGauges): Promise<void> {
-	const { completed, active, delayed, failed, waiting } = await queue.getJobCounts();
+	const { completed, active, delayed, failed, waiting, prioritized } = await queue.getJobCounts();
 
 	gauges.completed.set({ prefix, queue: name }, completed);
 	gauges.active.set({ prefix, queue: name }, active);
 	gauges.delayed.set({ prefix, queue: name }, delayed);
 	gauges.failed.set({ prefix, queue: name }, failed);
 	gauges.waiting.set({ prefix, queue: name }, waiting);
+	gauges.prioritized.set({ prefix, queue: name }, prioritized);
 }


### PR DESCRIPTION
<!--
## Pull Request template
-->
### Description
<!-- enter a description of your change here -->

- Upgraded bullmq version to newest one, as 3.*.* versions lacked priority related stats in the function return payload that is used for stats collection
- Added new property for prioritized messages counter

### This is a 
<!-- Pick One -->
- [ ] Bug Fix
- [x] Feature
- [ ] Documentation
- [ ] Other

## Checklists
#### Commit style
   <!-- Check all the following -->
   - [x] Changes are on a branch with a descriptive name eg. `fix/missing-queue`, `docs/setup-guide`
   
   - [x] Commits start with one of `feat:` `fix:` `docs:` `chore:` or similar
   
   - [x] No excessive commits, eg: there should be no `fix:` commits for bugs that existed only on the PR branch (see [guide-to-interactive-rebasing](https://hackernoon.com/beginners-guide-to-interactive-rebasing-346a3f9c3a6d))

#### Protected files

The following files should not change unless they are directly a part of your change.
    <!-- Check any of the bellow files that have changed, add a reason for each if nessesary  -->
   - [ ] `yarn.lock` (unless package.json is also modified, then only the new/updated package should be changed here)
   
   - [ ] `package.json` (renovate bot should handle all routine updates)

   - [ ] `package-lock.json` (Should not exist as this project uses yarn)
   
   - [ ] `tsconfig.json` (only make it stricter, making it more lenient requires more discussion)
   
   - [ ] `tslint.json` (only make it stricter, making it more lenient requires more discussion)
